### PR TITLE
add missing models for assets classification

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -5,6 +5,8 @@ const modulesOSSUrl = {
     "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/mnist/weights.bin",
   ],
   assetsClassification: [
+    "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/assetsClassification/model.json",
+    "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/assetsClassification/mean.json",
     "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/assetsClassification/group1-shard1of13.bin",
     "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/assetsClassification/group1-shard2of13.bin",
     "https://ai-sample.oss-cn-hangzhou.aliyuncs.com/pipcook/showcase/assetsClassification/group1-shard3of13.bin",


### PR DESCRIPTION
This fixes the following error when accessing the asset classification tutorial:

```sh
Uncaught (in promise) Error: Request to /static/models/assetsClassification/model.json failed with status code 404. Please verify this URL points to the model JSON of the model to load.
    at t.<anonymous> (4.js:18)
    at 4.js:18
    at Object.next (4.js:18)
    at o (4.js:18)
``` 